### PR TITLE
refactor: Move Navbar to layout and make homepage static

### DIFF
--- a/app/board/[id]/page.tsx
+++ b/app/board/[id]/page.tsx
@@ -15,7 +15,6 @@ const AnonymousModeProvider = dynamic(
   () => import("@/components/board/AnonymousModeProvider")
 );
 const PostProvider = dynamic(() => import("@/components/board/PostProvider"));
-const NavBar = dynamic(() => import("@/components/common/NavBar"));
 const MemberManageModalComponent = dynamic(
   () => import("@/components/board/MemberManageModalComponent")
 );
@@ -71,7 +70,6 @@ export default async function BoardPage({ params }: Readonly<BoardPageProps>) {
 
   return (
     <>
-      <NavBar />
       <RTLProvider boardId={boardID}>
         <AnonymousModeProvider>
           <PostProvider

--- a/app/board/layout.tsx
+++ b/app/board/layout.tsx
@@ -1,0 +1,10 @@
+import NavBar from "@/components/common/NavBar";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <NavBar />
+      {children}
+    </>
+  );
+}

--- a/app/board/page.tsx
+++ b/app/board/page.tsx
@@ -5,7 +5,6 @@ import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
 import dynamic from "next/dynamic";
 import { redirect } from "next/navigation";
 
-const NavBar = dynamic(() => import("@/components/common/NavBar"));
 const ToastSystem = dynamic(() => import("@/components/common/ToastSystem"));
 const BoardList = dynamic(() => import("@/components/home/BoardList"));
 const CreateBoardForm = dynamic(() => import("@/components/home/CreateBoardForm"));
@@ -35,8 +34,6 @@ export default async function Boards() {
 
   return (
     <div className="min-h-screen bg-slate-50">
-      <NavBar />
-
       <div className="container mx-auto mt-8 px-4">
         <h1 className="text-3xl font-bold mb-6">Your Boards</h1>
         <div className="flex flex-wrap gap-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,10 @@
 import { Button } from "@/components/ui/button";
-import {
-  getKindeServerSession,
-  LoginLink,
-} from "@kinde-oss/kinde-auth-nextjs/server";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 
 const GlowEffect = dynamic(() => import("@/components/landing/GlowEffect"));
 
 export default async function Home() {
-  const { isAuthenticated } = getKindeServerSession();
-  const isUserAuthenticated = await isAuthenticated();
-
   return (
     <div className="relative min-h-screen flex flex-col items-center justify-center bg-slate-100 overflow-hidden">
       <GlowEffect />
@@ -22,11 +15,7 @@ export default async function Home() {
         Made retro a breeze with ReeBoard
       </h2>
       <Button className="bg-slate-600 text-white hover:bg-slate-700 transition-colors duration-200 relative z-10 h-14 w-22 text-lg">
-        {isUserAuthenticated ? (
-          <LoginLink>Login</LoginLink>
-        ) : (
-          <Link href="/board">Board</Link>
-        )}
+        <Link href="/board">Start retro</Link>
       </Button>
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Layout` component for consistent page structure, including the `NavBar`.

- **User Interface Changes**
	- Removed the `NavBar` from the `BoardPage` and `Boards` components, simplifying the layout.
	- Updated the home page button to consistently link to the board with the label "Start retro."

- **Bug Fixes**
	- Eliminated unnecessary authentication checks, streamlining user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->