### PR TITLE
feat(voting): replace SQL triggers with application-level vote count management

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,10 @@
     "allow": [
       "mcp__context7__resolve-library-id",
       "mcp__context7__get-library-docs",
-      "mcp__sequential-thinking__sequentialthinking"
+      "mcp__sequential-thinking__sequentialthinking",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:gemini.google.com)",
+      "WebFetch(domain:orm.drizzle.team)"
     ],
     "deny": []
   }

--- a/lib/actions/vote/action.ts
+++ b/lib/actions/vote/action.ts
@@ -12,37 +12,53 @@ export const UpVotePostAction = async (
   userId: User["id"],
   boardId: Board["id"]
 ) =>
-  actionWithAuth(() =>
-    Promise.all([
-      upVote(postId, userId, boardId),
-      ablyClient(boardId).publish({
-        name: EVENT_TYPE.POST.UPVOTE,
-        extras: {
-          headers: {
-            user: userId,
-          },
+  actionWithAuth(async () => {
+    // Perform the upvote and get the updated count
+    const voteCount = await upVote(postId, userId, boardId);
+
+    // Publish real-time event with operation info (not absolute count)
+    await ablyClient(boardId).publish({
+      name: EVENT_TYPE.POST.UPVOTE,
+      extras: {
+        headers: {
+          user: userId,
         },
-        data: JSON.stringify({ id: postId }),
+      },
+      data: JSON.stringify({ 
+        id: postId, 
+        operation: 'upvote',
+        userId: userId,
+        timestamp: Date.now()
       }),
-    ])
-  );
+    });
+
+    return { voteCount };
+  });
 
 export const DownVotePostAction = async (
   postId: Post["id"],
   userId: User["id"],
   boardId: Board["id"]
 ) =>
-  actionWithAuth(() =>
-    Promise.all([
-      downVote(postId, userId, boardId),
-      ablyClient(boardId).publish({
-        name: EVENT_TYPE.POST.DOWNVOTE,
-        extras: {
-          headers: {
-            user: userId,
-          },
+  actionWithAuth(async () => {
+    // Perform the downvote and get the updated count
+    const voteCount = await downVote(postId, userId, boardId);
+
+    // Publish real-time event with operation info (not absolute count)
+    await ablyClient(boardId).publish({
+      name: EVENT_TYPE.POST.DOWNVOTE,
+      extras: {
+        headers: {
+          user: userId,
         },
-        data: JSON.stringify({ id: postId }),
+      },
+      data: JSON.stringify({ 
+        id: postId, 
+        operation: 'downvote',
+        userId: userId,
+        timestamp: Date.now()
       }),
-    ])
-  );
+    });
+
+    return { voteCount };
+  });

--- a/lib/db/vote.ts
+++ b/lib/db/vote.ts
@@ -1,8 +1,8 @@
-import { voteTable } from "@/db/schema";
+import { voteTable, postTable } from "@/db/schema";
 import type { Board } from "@/lib/types/board";
 import type { Post } from "@/lib/types/post";
 import type { User } from "@/lib/types/user";
-import { and, eq, sql } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { db } from "./client";
 
@@ -10,29 +10,61 @@ export async function upVote(
   postId: Post["id"],
   userId: User["id"],
   boardId: Board["id"]
-) {
-  await db.insert(voteTable).values({
-    id: nanoid(),
-    userId,
-    postId,
-    boardId,
-  });
+): Promise<number> {
+  const batchResults = await db.batch([
+    db.insert(voteTable).values({
+      id: nanoid(),
+      userId,
+      postId,
+      boardId,
+    }),
+    db
+      .update(postTable)
+      .set({
+        voteCount: sql`${db
+          .select({ count: count() })
+          .from(voteTable)
+          .where(eq(voteTable.postId, postId))}`,
+      })
+      .where(eq(postTable.id, postId))
+      .returning({ voteCount: postTable.voteCount }),
+  ]);
+
+  // Extract vote count from the select result
+  const selectResult = batchResults[1];
+  return selectResult[0].voteCount;
 }
 
 export async function downVote(
   postId: Post["id"],
   userId: User["id"],
   boardId: Board["id"]
-) {
-  await db
-    .delete(voteTable)
-    .where(
-      and(
-        eq(voteTable.postId, postId),
-        eq(voteTable.userId, userId),
-        eq(voteTable.boardId, boardId)
-      )
-    );
+): Promise<number> {
+  const batchResults = await db.batch([
+    db
+      .delete(voteTable)
+      .where(
+        and(
+          eq(voteTable.postId, postId),
+          eq(voteTable.userId, userId),
+          eq(voteTable.boardId, boardId)
+        )
+      ),
+    db
+      .update(postTable)
+      .set({
+        voteCount: sql`${db
+          .select({ count: count() })
+          .from(voteTable)
+          .where(eq(voteTable.postId, postId))}`,
+      })
+      .where(eq(postTable.id, postId))
+      .returning({ voteCount: postTable.voteCount }),
+  ]);
+
+  // Extract vote count from the select result
+  const selectResult = batchResults[1];
+  return selectResult[0].voteCount;
 }
 
 const prepareFetchUserVotedPost = db


### PR DESCRIPTION
- Replace hidden SQL triggers with explicit Drizzle batch operations
- Implement atomic vote count updates using db.batch() API
- Add race condition protection for real-time Ably events
- Return actual vote counts from server actions for immediate UI updates

Database operations (lib/db/vote.ts):
- Update upVote/downVote to use batch operations for atomicity
- Perform insert/update/select in single batch transaction
- Return actual vote count from database

Server actions (lib/actions/vote/action.ts):
- Send operation-based events instead of absolute counts via Ably
- Include userId and timestamp to prevent race conditions
- Return vote count to client for optimistic update reconciliation

Real-time events (PostChannelComponent.tsx):
- Filter own actions to prevent double-counting
- Ignore old messages using timestamp validation
- Use operation-based updates (increment/decrement) for resilience

Client-side voting (PostCard.tsx):
- Implement optimistic updates with server reconciliation
- Add error handling with rollback on failure
- Use actual server response for authoritative vote counts

Configuration:
- Add Jest moduleNameMapper for @/ path resolution
- Create comprehensive implementation documentation

BREAKING CHANGE: SQL triggers must be removed from Turso DB after deployment

Closes #426

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced voting experience with immediate UI updates when voting on posts, providing instant feedback.
  * Voting now automatically rolls back UI changes if a vote fails, ensuring accurate vote counts.

* **Bug Fixes**
  * Improved real-time vote synchronization to avoid double-counting votes from the same user and to ignore outdated vote events.

* **Chores**
  * Updated permissions to allow web fetching from additional trusted domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->