### PR TITLE
fix: merge post event process not updating the target post

### DIFF
--- a/lib/realtime/messageProcessors.ts
+++ b/lib/realtime/messageProcessors.ts
@@ -5,6 +5,7 @@ import {
   decrementPostVoteCount,
   incrementPostVoteCount,
   removePost,
+  updatePost,
   updatePostContent,
   updatePostState,
   updatePostType,
@@ -442,7 +443,7 @@ export function processPostMessage(
 
         // Update the target post with merged data
         if (isValidPost(mergeData.mergedPost)) {
-          addPost(mergeData.mergedPost);
+          updatePost(mergeData.targetPostId, mergeData.mergedPost);
           // Remove source posts from state
           mergeData.deletedPostIds.forEach((postId) => {
             removePost(postId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merged posts now update the original post in real time instead of creating duplicates.
  * Ensures only valid merged content is applied, preventing incorrect or partial updates.
  * Keeps timelines and threads consistent by removing content marked as deleted after merges.
  * Reduces feed flicker and confusion during rapid updates for a smoother reading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->