### PR TITLE
feat: add cron job for expired guest user cleanup

### DIFF
--- a/app/api/cron/cleanup-guests/route.ts
+++ b/app/api/cron/cleanup-guests/route.ts
@@ -1,0 +1,83 @@
+import { cleanupExpiredGuestUsers } from "@/lib/jobs/cleanupGuestUsers";
+import { NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Cron endpoint to cleanup expired guest users
+ *
+ * This endpoint is triggered by Vercel Cron Jobs daily at 2am UTC.
+ * It removes guest users whose 30-day expiration period has passed.
+ *
+ * SECURITY:
+ * - Protected by CRON_SECRET environment variable
+ * - Only accepts requests with valid Bearer token
+ * - Intended to be called by Vercel Cron system
+ *
+ * CONFIGURATION:
+ * - Schedule: 0 2 * * * (daily at 2am UTC)
+ * - Configured in vercel.json
+ *
+ * @param request - Next.js request object
+ * @returns JSON response with cleanup results
+ */
+export async function GET(request: Request) {
+  // Verify cron secret
+  const authHeader = request.headers.get("authorization");
+  const expectedAuth = `Bearer ${process.env.CRON_SECRET}`;
+
+  if (!process.env.CRON_SECRET) {
+    console.error(
+      "[Cron Cleanup] CRON_SECRET environment variable is not configured"
+    );
+    return NextResponse.json(
+      { error: "Server configuration error" },
+      { status: 500 }
+    );
+  }
+
+  const isValidAuth =
+    authHeader?.length === expectedAuth.length &&
+    timingSafeEqual(Buffer.from(authHeader || ""), Buffer.from(expectedAuth));
+
+  if (!isValidAuth) {
+    console.warn("[Cron Cleanup] Unauthorized access attempt");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    console.log("[Cron Cleanup] Starting scheduled guest cleanup job");
+
+    const deletedCount = await cleanupExpiredGuestUsers();
+
+    // Extract pluralization logic to avoid nested ternary
+    const pluralSuffix = deletedCount === 1 ? "" : "s";
+    const successMessage = `Successfully deleted ${deletedCount} expired guest user${pluralSuffix}`;
+
+    const response = {
+      success: true,
+      cleanedUp: deletedCount,
+      timestamp: new Date().toISOString(),
+      message:
+        deletedCount > 0 ? successMessage : "No expired guests to clean up",
+    };
+
+    console.log("[Cron Cleanup] Job completed successfully:", response);
+
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    console.error("[Cron Cleanup] Job failed with error:", error);
+
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error occurred";
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Cleanup failed",
+        details: errorMessage,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/jobs/cleanupGuestUsers.ts
+++ b/lib/jobs/cleanupGuestUsers.ts
@@ -1,0 +1,89 @@
+import { userTable } from "@/db/schema";
+import { db } from "@/lib/db/client";
+import { and, eq, lt } from "drizzle-orm";
+
+/**
+ * Cleanup job to remove expired guest users
+ *
+ * Guest users are created with a 30-day expiration period.
+ * This job finds and deletes guest users whose expiration date has passed.
+ *
+ * CASCADE DELETE BEHAVIOR:
+ * When a user is deleted, the following related data is automatically cleaned up
+ * due to foreign key constraints:
+ * - member (cascade) - Board memberships
+ * - vote (cascade) - User votes
+ * - post (set null) - Posts authored by the user (author set to null)
+ * - task (set null) - Tasks created by the user (userId set to null)
+ * - board (set null) - Boards created by the user (creator set to null)
+ * - links (set null) - Invite links created by the user (creator set to null)
+ *
+ * @returns Number of guest users deleted
+ */
+export async function cleanupExpiredGuestUsers(): Promise<number> {
+  const now = new Date();
+
+  console.log("[Guest Cleanup] Starting cleanup job...");
+  console.log(`[Guest Cleanup] Current time: ${new Date().toISOString()}`);
+
+  // Find expired guests
+  // Query for users where:
+  // - isGuest = true
+  // - guestExpiresAt < current timestamp (expired)
+  const expiredGuests = await db
+    .select({
+      id: userTable.id,
+      name: userTable.name,
+      guestExpiresAt: userTable.guestExpiresAt,
+    })
+    .from(userTable)
+    .where(and(eq(userTable.isGuest, true), lt(userTable.guestExpiresAt, now)));
+
+  console.log(
+    `[Guest Cleanup] Found ${expiredGuests.length} expired guest users`
+  );
+
+  if (expiredGuests.length === 0) {
+    console.log("[Guest Cleanup] No expired guests to clean up");
+    return 0;
+  }
+
+  // Log details of guests being deleted (for audit trail)
+  expiredGuests.forEach((guest) => {
+    const expiryDate = guest.guestExpiresAt
+      ? guest.guestExpiresAt.toISOString()
+      : "unknown";
+    console.log(
+      `[Guest Cleanup] Deleting guest: ${guest.name} (ID: ${guest.id}, expired: ${expiryDate})`
+    );
+  });
+
+  let deletedCount = 0;
+
+  // Delete each expired guest
+  // Cascade deletes will automatically handle related data
+  for (const guest of expiredGuests) {
+    try {
+      const result = await db
+        .delete(userTable)
+        .where(eq(userTable.id, guest.id))
+        .returning({ deletedId: userTable.id });
+
+      if (result.length > 0) {
+        deletedCount++;
+        console.log(`[Guest Cleanup] ✓ Deleted guest: ${guest.name}`);
+      }
+    } catch (error) {
+      console.error(
+        `[Guest Cleanup] ✗ Failed to delete guest ${guest.name}:`,
+        error
+      );
+    }
+  }
+
+  console.log(
+    `[Guest Cleanup] Cleanup complete. Deleted ${deletedCount}/${expiredGuests.length} guests`
+  );
+
+  return deletedCount;
+}

--- a/scripts/test-guest-cleanup.ts
+++ b/scripts/test-guest-cleanup.ts
@@ -1,0 +1,212 @@
+/**
+ * Test script for guest user cleanup job
+ *
+ * This script tests the cleanup job by:
+ * 1. Creating test guests (both expired and active)
+ * 2. Running the cleanup job
+ * 3. Verifying only expired guests are deleted
+ * 4. Cleaning up test data
+ *
+ * Usage: npx tsx scripts/test-guest-cleanup.ts
+ */
+
+import { cleanupExpiredGuestUsers } from "@/lib/jobs/cleanupGuestUsers";
+import { createGuestUser, getUserByUserID, deleteUser } from "@/lib/db/user";
+import { nanoid } from "nanoid";
+
+interface TestGuest {
+  id: string;
+  name: string;
+  isExpired: boolean;
+}
+
+async function testGuestCleanup() {
+  console.log("=".repeat(60));
+  console.log("Guest Cleanup Job - Test Script");
+  console.log("=".repeat(60));
+  console.log("");
+
+  const testGuests: TestGuest[] = [];
+
+  try {
+    // Step 1: Create test guests
+    console.log("Step 1: Creating test guests...");
+    console.log("");
+
+    // Create 2 expired guests (expired 1 day ago)
+    for (let i = 1; i <= 2; i++) {
+      const id = nanoid();
+      const expiredDate = new Date(Date.now() - 24 * 60 * 60 * 1000); // 1 day ago
+
+      await createGuestUser({
+        id,
+        supabase_id: `test_expired_${id}`,
+        name: `TestExpiredGuest_${i}`,
+        guestExpiresAt: expiredDate,
+      });
+
+      testGuests.push({
+        id,
+        name: `TestExpiredGuest_${i}`,
+        isExpired: true,
+      });
+
+      console.log(
+        `✓ Created expired guest: TestExpiredGuest_${i} (expires: ${expiredDate.toISOString()})`
+      );
+    }
+
+    // Create 2 active guests (expires in 29 days)
+    for (let i = 1; i <= 2; i++) {
+      const id = nanoid();
+      const futureDate = new Date(Date.now() + 29 * 24 * 60 * 60 * 1000); // 29 days from now
+
+      await createGuestUser({
+        id,
+        supabase_id: `test_active_${id}`,
+        name: `TestActiveGuest_${i}`,
+        guestExpiresAt: futureDate,
+      });
+
+      testGuests.push({
+        id,
+        name: `TestActiveGuest_${i}`,
+        isExpired: false,
+      });
+
+      console.log(
+        `✓ Created active guest: TestActiveGuest_${i} (expires: ${futureDate.toISOString()})`
+      );
+    }
+
+    console.log("");
+    console.log(
+      `Created ${testGuests.length} test guests (2 expired, 2 active)`
+    );
+    console.log("");
+
+    // Step 2: Verify guests exist before cleanup
+    console.log("Step 2: Verifying test guests exist in database...");
+    console.log("");
+
+    for (const guest of testGuests) {
+      const user = await getUserByUserID(guest.id);
+      if (user) {
+        console.log(`✓ Found: ${guest.name} (${guest.isExpired ? 'expired' : 'active'})`);
+      } else {
+        console.log(`✗ Not found: ${guest.name}`);
+      }
+    }
+
+    console.log("");
+
+    // Step 3: Run cleanup job
+    console.log("Step 3: Running cleanup job...");
+    console.log("");
+    console.log("-".repeat(60));
+
+    const deletedCount = await cleanupExpiredGuestUsers();
+
+    console.log("-".repeat(60));
+    console.log("");
+    console.log(`Cleanup job completed. Deleted ${deletedCount} guests.`);
+    console.log("");
+
+    // Step 4: Verify results
+    console.log("Step 4: Verifying cleanup results...");
+    console.log("");
+
+    let expiredStillExist = 0;
+    let activeDeleted = 0;
+
+    for (const guest of testGuests) {
+      const user = await getUserByUserID(guest.id);
+
+      if (guest.isExpired) {
+        // Expired guests should be deleted
+        if (user) {
+          console.log(`✗ FAIL: Expired guest still exists: ${guest.name}`);
+          expiredStillExist++;
+        } else {
+          console.log(`✓ PASS: Expired guest deleted: ${guest.name}`);
+        }
+      } else {
+        // Active guests should remain
+        if (user) {
+          console.log(`✓ PASS: Active guest preserved: ${guest.name}`);
+        } else {
+          console.log(`✗ FAIL: Active guest was deleted: ${guest.name}`);
+          activeDeleted++;
+        }
+      }
+    }
+
+    console.log("");
+    console.log("=".repeat(60));
+    console.log("Test Results:");
+    console.log("=".repeat(60));
+
+    const allTestsPassed = expiredStillExist === 0 && activeDeleted === 0;
+
+    if (allTestsPassed) {
+      console.log("✓ ALL TESTS PASSED");
+      console.log(`  - ${deletedCount} expired guests deleted`);
+      console.log("  - 2 active guests preserved");
+      console.log("  - No false positives");
+    } else {
+      console.log("✗ TESTS FAILED");
+      if (expiredStillExist > 0) {
+        console.log(`  - ${expiredStillExist} expired guests NOT deleted`);
+      }
+      if (activeDeleted > 0) {
+        console.log(`  - ${activeDeleted} active guests incorrectly deleted`);
+      }
+    }
+
+    console.log("");
+
+    // Step 5: Cleanup test data
+    console.log("Step 5: Cleaning up test data...");
+    console.log("");
+
+    for (const guest of testGuests) {
+      const user = await getUserByUserID(guest.id);
+      if (user) {
+        await deleteUser(guest.id);
+        console.log(`✓ Cleaned up: ${guest.name}`);
+      }
+    }
+
+    console.log("");
+    console.log("Test script completed successfully!");
+    console.log("=".repeat(60));
+
+    process.exit(allTestsPassed ? 0 : 1);
+  } catch (error) {
+    console.error("");
+    console.error("=".repeat(60));
+    console.error("Test failed with error:");
+    console.error("=".repeat(60));
+    console.error(error);
+    console.error("");
+
+    // Try to cleanup test data even on error
+    console.log("Attempting to clean up test guests...");
+    for (const guest of testGuests) {
+      try {
+        const user = await getUserByUserID(guest.id);
+        if (user) {
+          await deleteUser(guest.id);
+          console.log(`✓ Cleaned up: ${guest.name}`);
+        }
+      } catch (cleanupError) {
+        console.error(`✗ Failed to cleanup ${guest.name}:`, cleanupError);
+      }
+    }
+
+    process.exit(1);
+  }
+}
+
+// Run the test
+testGuestCleanup();

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/cleanup-guests",
+      "schedule": "0 2 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Add scheduled cleanup system for guest users whose 30-day expiration period has passed:

- Create API endpoint at /api/cron/cleanup-guests protected by CRON_SECRET
- Implement cleanupExpiredGuestUsers job to find and delete expired guests
- Configure Vercel cron schedule to run daily at 2am UTC
- Add proper logging and error handling for audit trail

Relies on existing cascade delete constraints to clean up related data (memberships, votes) and set null for authored content (posts, tasks, boards).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic daily cleanup of expired guest accounts (runs at 2:00 AM) with JSON reporting of results.
  * Cleanup endpoint enforces a configured secret and authorization for secured runs.

* **Tests**
  * Added an end-to-end test script that verifies expired guests are removed and active guests remain.

* **Chores**
  * Added scheduled job configuration and improved error handling and logging for the cleanup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->