### PR TITLE
fix(auth): update sign-in redirects to home page

### DIFF
--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -97,7 +97,7 @@ export default function ResetPasswordPage() {
               This password reset link is invalid or has expired. Please request
               a new one.
             </p>
-            <Link href="/sign-in">
+            <Link href="/">
               <Button className="w-full bg-slate-600 hover:bg-slate-700">
                 Back to Sign In
               </Button>
@@ -203,7 +203,7 @@ export default function ResetPasswordPage() {
 
           <div className="mt-6 pt-6 border-t border-slate-200 text-center">
             <Link
-              href="/sign-in"
+              href="/"
               className="text-sm text-slate-600 hover:text-slate-800"
             >
               ← Back to Sign In

--- a/lib/auth/getAuthenticatedUser.ts
+++ b/lib/auth/getAuthenticatedUser.ts
@@ -26,7 +26,7 @@ export type AuthResult = {
  * ```typescript
  * const authResult = await getAuthenticatedUser();
  * if (!authResult) {
- *   redirect("/sign-in");
+ *   redirect("/");
  * }
  * // Use authResult.userId for database operations
  * // Check authResult.isGuest for permission logic

--- a/lib/dal.ts
+++ b/lib/dal.ts
@@ -24,7 +24,7 @@ export const verifySession = cache(async (): Promise<VerifiedSession> => {
   const { data: { user } } = await supabase.auth.getUser()
 
   if (!user) {
-    redirect('/sign-in')
+    redirect('/')
   }
 
   // Look up internal user by Supabase ID
@@ -35,7 +35,7 @@ export const verifySession = cache(async (): Promise<VerifiedSession> => {
   if (!internalUser) {
     // Don't auto-create for anonymous users (they have their own flow)
     if (user.is_anonymous) {
-      redirect('/sign-in')
+      redirect('/')
     }
 
     // Auto-create user record (similar to Kinde webhook)
@@ -80,7 +80,7 @@ export const getCurrentUser = cache(async () => {
   const { data: { user } } = await supabase.auth.getUser()
 
   if (!user) {
-    redirect('/sign-in')
+    redirect('/')
   }
 
   return user

--- a/lib/utils/supabase/middleware.test.ts
+++ b/lib/utils/supabase/middleware.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { User } from "@supabase/supabase-js";
+import { NextRequest } from "next/server";
+import { updateSession } from "./middleware";
+
+interface MockCookie {
+  name: string;
+  value: string;
+  options: {
+    httpOnly: boolean;
+    path: string;
+  };
+}
+
+interface MockClientOptions {
+  cookies: {
+    setAll(cookies: MockCookie[]): void;
+  };
+}
+
+const authenticatedUser = { id: "user-1" } as User;
+const mockGetUser = jest.fn<
+  () => Promise<{ data: { user: User | null } }>
+>();
+
+jest.mock("@supabase/ssr", () => ({
+  createServerClient: jest.fn(
+    (_url: string, _key: string, options: MockClientOptions) => ({
+      auth: {
+        getUser: async () => {
+          options.cookies.setAll([
+            {
+              name: "sb-session",
+              value: "refreshed",
+              options: { httpOnly: true, path: "/" },
+            },
+          ]);
+          return mockGetUser();
+        },
+      },
+    }),
+  ),
+}));
+
+describe("updateSession", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+    mockGetUser.mockResolvedValue({ data: { user: authenticatedUser } });
+  });
+
+  it("redirects authenticated root requests to a safe internal destination", async () => {
+    const redirect = encodeURIComponent("/board/board-1?tab=summary");
+    const request = new NextRequest(
+      `http://localhost:3000/?redirect=${redirect}`,
+    );
+
+    const { response, user } = await updateSession(request);
+
+    expect(user).toBe(authenticatedUser);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/board/board-1?tab=summary",
+    );
+    expect(response.cookies.get("sb-session")?.value).toBe("refreshed");
+  });
+
+  it.each([
+    "/\n/evil.example",
+    "/\r/evil.example",
+    "/\t/evil.example",
+    "//evil.example",
+    "/\\evil.example",
+    "//",
+    "///",
+    "//[",
+  ])(
+    "rejects an unsafe redirect payload",
+    async (redirect) => {
+      const request = new NextRequest(
+        `http://localhost:3000/?redirect=${encodeURIComponent(redirect)}`,
+      );
+
+      const { response } = await updateSession(request);
+
+      expect(response.headers.get("location")).toBe(
+        "http://localhost:3000/board",
+      );
+      expect(response.cookies.get("sb-session")?.value).toBe("refreshed");
+    },
+  );
+});

--- a/lib/utils/supabase/middleware.ts
+++ b/lib/utils/supabase/middleware.ts
@@ -1,6 +1,32 @@
 import { createServerClient } from "@supabase/ssr";
+import type { User } from "@supabase/supabase-js";
 import { NextResponse, type NextRequest } from "next/server";
 import invariant from "tiny-invariant";
+
+interface SessionUpdateResult {
+  response: NextResponse;
+  user: User | null;
+}
+
+function getSafeRedirectUrl(
+  redirectParam: string | null,
+  request: NextRequest,
+): URL {
+  const fallbackUrl = new URL("/board", request.url);
+
+  if (!redirectParam?.startsWith("/")) {
+    return fallbackUrl;
+  }
+
+  try {
+    const requestedUrl = new URL(redirectParam, request.url);
+    return requestedUrl.origin === request.nextUrl.origin
+      ? requestedUrl
+      : fallbackUrl;
+  } catch {
+    return fallbackUrl;
+  }
+}
 
 /**
  * Updates and refreshes the Supabase session in middleware
@@ -12,12 +38,14 @@ import invariant from "tiny-invariant";
  * 1. Creates a Supabase client for middleware
  * 2. Refreshes the user session by calling getUser()
  * 3. Updates cookies in both request and response
- * 4. Redirects authenticated users away from /sign-in
+ * 4. Redirects authenticated users away from /
  *
  * @param request - The incoming Next.js request
- * @returns NextResponse with updated cookies or redirect
+ * @returns The authenticated user and a response with updated cookies or redirect
  */
-export async function updateSession(request: NextRequest) {
+export async function updateSession(
+  request: NextRequest,
+): Promise<SessionUpdateResult> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
@@ -62,20 +90,14 @@ export async function updateSession(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Special handling for sign-in page: redirect authenticated users to /board
-  if (pathname === "/sign-in" && user) {
+  if (pathname === "/" && user) {
     // User is authenticated and trying to access sign-in page
     // Check if there's a redirect parameter they were trying to reach
     const redirectParam = request.nextUrl.searchParams.get("redirect");
 
-    // If redirect exists and is a safe internal path, use it; otherwise go to /board
-    const destination =
-      redirectParam?.startsWith("/") &&
-      !redirectParam.startsWith("//") &&
-      !redirectParam.startsWith("/\\")
-        ? redirectParam
-        : "/board";
-
-    const redirectUrl = new URL(destination, request.url);
+    // Resolve the redirect before trusting it because URL parsing strips some
+    // control characters that can turn an apparent path into another origin.
+    const redirectUrl = getSafeRedirectUrl(redirectParam, request);
 
     // Create redirect response and copy cookies
     const redirectResponse = NextResponse.redirect(redirectUrl);
@@ -83,7 +105,7 @@ export async function updateSession(request: NextRequest) {
       redirectResponse.cookies.set(cookie.name, cookie.value, cookie);
     });
 
-    return redirectResponse;
+    return { response: redirectResponse, user };
   }
 
   // IMPORTANT: You *must* return the supabaseResponse object as it is.
@@ -99,5 +121,5 @@ export async function updateSession(request: NextRequest) {
   // If this is not done, you may be causing the browser and server to go out
   // of sync and terminate the user's session prematurely!
 
-  return supabaseResponse;
+  return { response: supabaseResponse, user };
 }

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { User } from "@supabase/supabase-js";
+import { NextRequest, NextResponse } from "next/server";
+import { updateSession } from "@/lib/utils/supabase/middleware";
+import { proxy } from "@/proxy";
+
+jest.mock("@/lib/utils/supabase/middleware", () => ({
+  updateSession: jest.fn(),
+}));
+
+const mockUpdateSession = jest.mocked(updateSession);
+const authenticatedUser = { id: "user-1" } as User;
+
+describe("proxy", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("redirects unauthenticated protected requests and preserves refreshed cookies", async () => {
+    const request = new NextRequest("http://localhost:3000/board/board-1");
+    const sessionResponse = NextResponse.next();
+    sessionResponse.cookies.set("sb-session", "refreshed");
+    mockUpdateSession.mockResolvedValue({
+      response: sessionResponse,
+      user: null,
+    });
+
+    const response = await proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?redirect=%2Fboard%2Fboard-1",
+    );
+    expect(response.cookies.get("sb-session")?.value).toBe("refreshed");
+  });
+
+  it("lets unauthenticated users access the root route", async () => {
+    const request = new NextRequest("http://localhost:3000/");
+    const sessionResponse = NextResponse.next();
+    mockUpdateSession.mockResolvedValue({
+      response: sessionResponse,
+      user: null,
+    });
+
+    const response = await proxy(request);
+
+    expect(mockUpdateSession).toHaveBeenCalledWith(request);
+    expect(response).toBe(sessionResponse);
+  });
+
+  it("returns the authenticated root redirect from the session updater", async () => {
+    const request = new NextRequest("http://localhost:3000/");
+    const sessionResponse = NextResponse.redirect(
+      "http://localhost:3000/board",
+    );
+    mockUpdateSession.mockResolvedValue({
+      response: sessionResponse,
+      user: authenticatedUser,
+    });
+
+    const response = await proxy(request);
+
+    expect(response).toBe(sessionResponse);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/board",
+    );
+  });
+
+  it("continues to bypass session checks for other public routes", async () => {
+    const request = new NextRequest("http://localhost:3000/reset-password");
+
+    const response = await proxy(request);
+
+    expect(mockUpdateSession).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -13,7 +13,6 @@ import { updateSession } from "@/lib/utils/supabase/middleware";
 export async function proxy(request: NextRequest) {
   // Public routes that don't require authentication
   const publicPaths = [
-    "/",
     "/sign-in",
     "/reset-password",
     "/invite",
@@ -33,17 +32,21 @@ export async function proxy(request: NextRequest) {
   }
 
   // Update session (refresh cookies) and get user for all requests
-  const session = await updateSession(request);
+  const { response, user } = await updateSession(request);
 
   // For protected routes, check if user is authenticated
-  if (!session) {
+  if (!user && pathname !== "/") {
     // No user on protected route - redirect to sign-in
-    const redirectUrl = new URL("/sign-in", request.url);
+    const redirectUrl = new URL("/", request.url);
     redirectUrl.searchParams.set("redirect", pathname);
-    return NextResponse.redirect(redirectUrl);
+    const redirectResponse = NextResponse.redirect(redirectUrl);
+    response.cookies.getAll().forEach((cookie) => {
+      redirectResponse.cookies.set(cookie.name, cookie.value, cookie);
+    });
+    return redirectResponse;
   }
 
-  return session;
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated authentication redirects to consistently use the home page instead of the sign-in page.
  - Unauthenticated visitors accessing protected pages are redirected home while preserving their intended destination.
  - Updated password reset navigation to return to the home page in invalid-link and form footer scenarios.
  - Authenticated visitors are redirected away from the home page as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->